### PR TITLE
Added new groups tab

### DIFF
--- a/src/components/CheckInList.js
+++ b/src/components/CheckInList.js
@@ -385,7 +385,7 @@ export default function CheckInList({
           sorting: {
             sortModel: [
               groupSummaryList && { field: 'group_id', sort: 'asc' },
-              groupSummaryList && { field: 'user_type_id', sort: 'asc'},
+              groupSummaryList && { field: 'type', sort: 'asc'},
               { field: 'first_name', sort: 'asc' }
             ],
           },

--- a/src/components/CheckInList.js
+++ b/src/components/CheckInList.js
@@ -356,6 +356,8 @@ export default function CheckInList({
     items: [],
   });
 
+  let sortModel = [{ field: 'first_name', sort: 'asc' }];
+
   const visibility = {
     id: false,
     fulltext: false,
@@ -369,6 +371,11 @@ export default function CheckInList({
   if (groupSummaryList) {
     visibility["checkin"] = false;
     visibility["type"] = true;
+    sortModel = [
+      { field: 'group_id', sort: 'asc' },
+      { field: 'type', sort: 'asc'},
+      { field: 'first_name', sort: 'asc' }
+    ];
   }
 
   return (
@@ -383,11 +390,7 @@ export default function CheckInList({
         columnVisibilityModel={visibility}
         initialState={{
           sorting: {
-            sortModel: [
-              groupSummaryList && { field: 'group_id', sort: 'asc' },
-              groupSummaryList && { field: 'type', sort: 'asc'},
-              { field: 'first_name', sort: 'asc' }
-            ],
+            sortModel: sortModel,
           },
         }}
       />

--- a/src/components/CheckInList.js
+++ b/src/components/CheckInList.js
@@ -285,6 +285,7 @@ export default function CheckInList({
       renderCell: renderAvatar(handleAvatarClick),
     },
     { field: "name", headerName: "Name", flex: 1.5 },
+    { field: "group_summary_sort", headerName: "GroupSummarySort", flex: 0 },
     { field: "fulltext", headerName: "Fulltext", flex: 0 },
   ];
 
@@ -362,6 +363,7 @@ export default function CheckInList({
     id: false,
     fulltext: false,
     type: false,
+    group_summary_sort: false,
   };
 
   if (hideGroup) {
@@ -372,9 +374,7 @@ export default function CheckInList({
     visibility["checkin"] = false;
     visibility["type"] = true;
     sortModel = [
-      { field: 'group_id', sort: 'asc' },
-      { field: 'type', sort: 'asc'},
-      { field: 'first_name', sort: 'asc' }
+      { field: 'group_summary_sort', sort: 'asc' }
     ];
   }
 

--- a/src/components/CheckInList.js
+++ b/src/components/CheckInList.js
@@ -80,6 +80,7 @@ export default function CheckInList({
   users,
   groups,
   oneStepCheckIn = false,
+  groupSummaryList = false,
   hideGroup = false,
 }) {
   const [isAvatarModalOpen, setAvatarModalOpen] = React.useState(false);
@@ -276,6 +277,7 @@ export default function CheckInList({
         return sortOrder.indexOf(param1.value) - sortOrder.indexOf(param2.value)
       }
     },
+    { field: "type", headerName: "User Type", flex: 1 },
     {
       field: "avatar",
       headerName: "Avatar",
@@ -357,10 +359,16 @@ export default function CheckInList({
   const visibility = {
     id: false,
     fulltext: false,
+    type: false,
   };
 
   if (hideGroup) {
     visibility["group_id"] = false;
+  }
+
+  if (groupSummaryList) {
+    visibility["checkin"] = false;
+    visibility["type"] = true;
   }
 
   return (
@@ -375,7 +383,11 @@ export default function CheckInList({
         columnVisibilityModel={visibility}
         initialState={{
           sorting: {
-            sortModel: [{ field: 'first_name', sort: 'asc' }],
+            sortModel: [
+              groupSummaryList && { field: 'group_id', sort: 'asc' },
+              groupSummaryList && { field: 'user_type_id', sort: 'asc'},
+              { field: 'first_name', sort: 'asc' }
+            ],
           },
         }}
       />

--- a/src/components/RideInfo.js
+++ b/src/components/RideInfo.js
@@ -85,8 +85,8 @@ const RideInfo = () => {
                         <TabPanel value={value} index={3}>
                             <CheckInList users={
                                 [
-                                    ...data?.currentRide?.Riders.filter(x => x.group_id > 0 && x.check_in == 1),
-                                    ...data?.currentRide?.Mentors.filter(x => x.group_id > 0 && x.check_in == 1)
+                                    ...data?.currentRide?.Riders.filter(x => x.group_id >= 0 && x.check_in == 1),
+                                    ...data?.currentRide?.Mentors.filter(x => x.group_id >= 0 && x.check_in == 1)
                                 ]
                             } groups={data?.currentRide?.Groups || []} groupSummaryList />
                         </TabPanel>

--- a/src/components/RideInfo.js
+++ b/src/components/RideInfo.js
@@ -49,7 +49,7 @@ const RideInfo = () => {
         console.log(data.setExportLoading);
         export_data(data.currentRide.Ride.ride_id, data.refresh, data.setExportLoading);
     }
-console.log(data?.currentRide?.Riders);
+
     return (
         <>
             <Box display={'flex'} justifyItems={'space-between'} mt={5} mb={'12px'}>

--- a/src/components/RideInfo.js
+++ b/src/components/RideInfo.js
@@ -49,7 +49,7 @@ const RideInfo = () => {
         console.log(data.setExportLoading);
         export_data(data.currentRide.Ride.ride_id, data.refresh, data.setExportLoading);
     }
-
+console.log(data?.currentRide?.Riders);
     return (
         <>
             <Box display={'flex'} justifyItems={'space-between'} mt={5} mb={'12px'}>
@@ -71,6 +71,7 @@ const RideInfo = () => {
                             <Tab label="Riders" {...a11yProps(0)} />
                             <Tab label="Mentors" {...a11yProps(1)} />
                             <Tab label="Stops" {...a11yProps(2)} />
+                            <Tab label="Groups" {...a11yProps(3)} />
                         </Tabs>
                         <TabPanel value={value} index={0}>
                             <CheckInList users={data?.currentRide?.Riders || []} groups={data?.currentRide?.Groups || []} />
@@ -80,6 +81,14 @@ const RideInfo = () => {
                         </TabPanel>
                         <TabPanel value={value} index={2}>
                             <Stops stops={data?.currentRide?.Stops || []} groupStops={data?.currentRide?.GroupStops || []} groups={data?.currentRide?.Groups || []} />
+                        </TabPanel>
+                        <TabPanel value={value} index={3}>
+                            <CheckInList users={
+                                [
+                                    ...data?.currentRide?.Riders.filter(x => x.group_id > 0 && x.check_in == 1),
+                                    ...data?.currentRide?.Mentors.filter(x => x.group_id > 0 && x.check_in == 1)
+                                ]
+                            } groups={data?.currentRide?.Groups || []} groupSummaryList />
                         </TabPanel>
                     </Box>
                 </Grid>

--- a/src/hooks/ride.js
+++ b/src/hooks/ride.js
@@ -50,12 +50,13 @@ export const getRideById = async (id) => {
   // console.log(rideSupport);
   const mentors = db.exec(
     `SELECT *, Users.user_id FROM Users ` +
+    `INNER JOIN UserTypes ON UserTypes.user_type_id = Users.user_type_id AND UserTypes.type='Mentor' ` +
     `LEFT JOIN (` +
     `    SELECT * FROM GroupAssignments` +
     `    LEFT JOIN Groups on GroupAssignments.group_id=Groups.group_id` +
     `    WHERE Groups.ride_id=${id}` +
     `) q ON q.user_id = Users.user_id ` +
-    `WHERE Users.user_type_id=(SELECT user_type_id FROM UserTypes WHERE type='Mentor') ` +
+    `WHERE UserTypes.type='Mentor' ` +
     `ORDER BY ride_id DESC, Users.first_name`
   )[0]
   // console.log(mentors);
@@ -63,12 +64,13 @@ export const getRideById = async (id) => {
   // console.log(mentorsObjArray);
   const riders = db.exec(
     `SELECT *, Users.user_id FROM Users ` +
+    `INNER JOIN UserTypes ON UserTypes.user_type_id = Users.user_type_id ` +
     `LEFT JOIN (` +
     `    SELECT * FROM GroupAssignments` +
     `    LEFT JOIN Groups on GroupAssignments.group_id=Groups.group_id` +
     `    WHERE Groups.ride_id=${id}` +
     `) q ON q.user_id = Users.user_id ` +
-    `WHERE Users.user_type_id=(SELECT user_type_id FROM UserTypes WHERE type='Rider') ` +
+    `WHERE UserTypes.type='Rider' ` +
     `ORDER BY ride_id DESC, Users.first_name`
   )[0];
   console.log(id, riders);

--- a/src/hooks/ride.js
+++ b/src/hooks/ride.js
@@ -50,7 +50,7 @@ export const getRideById = async (id) => {
   // console.log(rideSupport);
   const mentors = db.exec(
     `SELECT *, Users.user_id FROM Users ` +
-    `INNER JOIN UserTypes ON UserTypes.user_type_id = Users.user_type_id AND UserTypes.type='Mentor' ` +
+    `INNER JOIN UserTypes ON UserTypes.user_type_id = Users.user_type_id ` +
     `LEFT JOIN (` +
     `    SELECT * FROM GroupAssignments` +
     `    LEFT JOIN Groups on GroupAssignments.group_id=Groups.group_id` +

--- a/src/hooks/ride.js
+++ b/src/hooks/ride.js
@@ -49,7 +49,7 @@ export const getRideById = async (id) => {
   )[0];
   // console.log(rideSupport);
   const mentors = db.exec(
-    `SELECT *, Users.user_id FROM Users ` +
+    `SELECT *, Users.user_id, q.group_name || UserTypes.type || Users.first_name AS group_summary_sort FROM Users ` +
     `INNER JOIN UserTypes ON UserTypes.user_type_id = Users.user_type_id ` +
     `LEFT JOIN (` +
     `    SELECT * FROM GroupAssignments` +
@@ -63,7 +63,7 @@ export const getRideById = async (id) => {
   const mentorsObjArray = resultToObjArray(mentors);
   // console.log(mentorsObjArray);
   const riders = db.exec(
-    `SELECT *, Users.user_id FROM Users ` +
+    `SELECT *, Users.user_id, q.group_name || UserTypes.type || Users.first_name AS group_summary_sort FROM Users ` +
     `INNER JOIN UserTypes ON UserTypes.user_type_id = Users.user_type_id ` +
     `LEFT JOIN (` +
     `    SELECT * FROM GroupAssignments` +


### PR DESCRIPTION
- Added new Groups tab
- Updated rider and mentor queries to include user type description
- User can change group assignment from this new tab as well
- Note that Datagrid only allows a single column to be sorted, so I added a concatenated field to the user object called "group_summary_sort" so we could achieve multi column sorting on initial load

![image](https://github.com/DreamTeamDSM/DreamTeamCheckIn/assets/25083686/481e79b4-1c06-474c-ba8a-5b606bd13055)
